### PR TITLE
Small improvements to MPPatch

### DIFF
--- a/project/launch4j.xml
+++ b/project/launch4j.xml
@@ -25,6 +25,7 @@
   <headerType>gui</headerType>
   <jre>
     <minVersion>1.7.0</minVersion>
+    <maxVersion>1.8.1</maxVersion>
   </jre>
   <singleInstance>
     <mutexName>moe.lymia.mppatch.Launch4JStartupMutex</mutexName>
@@ -37,7 +38,7 @@
     <trademarks>MPPatch is licenced under the terms of the MIT License.</trademarks>
   </versionInfo>
   <messages>
-    <jreVersionErr>This application requires Java 7 or later to run.
+    <jreVersionErr>This application requires Java Runtime Environment 7 or later to run.
 Minimum version:</jreVersionErr>
   </messages>
 </launch4jConfig>

--- a/src/main/scala/moe/lymia/mppatch/core/platform.scala
+++ b/src/main/scala/moe/lymia/mppatch/core/platform.scala
@@ -72,9 +72,7 @@ object Win32Platform extends Platform {
   override val platformName = "win32"
 
   override def defaultSystemPaths: Seq[Path] = try {
-    WindowsRegistry.HKCU("Software\\Valve\\Steam", "SteamPath").toSeq.flatMap(
-      x => Steam.loadLibraryFolders(Paths.get(x))).map(_.resolve("SteamApps\\common\\Sid Meier's Civilization V")) ++
-    WindowsRegistry.HKCU("Software\\Firaxis\\Civilization5", "LastKnownPath").toSeq.map(x => Paths.get(x))
+    WindowsRegistry.HKLM("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App 8930", "InstallLocation").toSeq.map(x => Paths.get(x))
   } catch {
     case e: Exception =>
       SimpleLogger.error("Could not load default system paths from registery.", e)


### PR DESCRIPTION
- Fix multiple Java versions causing MPPatch to silently die on launch. Now limits itself to the widespread JRE8
- Better registry check for Civ5 installation directory. 

Through past experience with Civ5 mapscript installs and the like, this registry key has worked for iirc everyone. 
The normal key fails for 1/5 people or so.